### PR TITLE
Fix return value when encode is not successful

### DIFF
--- a/skv.go
+++ b/skv.go
@@ -84,7 +84,7 @@ func (kvs *KVStore) Put(key string, value interface{}) error {
 	}
 	var buf bytes.Buffer
 	if err := gob.NewEncoder(&buf).Encode(value); err != nil {
-		return nil
+		return err
 	}
 	return kvs.db.Update(func(tx *bolt.Tx) error {
 		return tx.Bucket(bucketName).Put([]byte(key), buf.Bytes())


### PR DESCRIPTION
When using structs with embedded fields `gob` is not able to encode them (https://github.com/golang/go/issues/5819) and returns error. This situation was not properly handled in `skv`.